### PR TITLE
Always create RemoteViews with Intent set

### DIFF
--- a/src/AndroidManifest.xml
+++ b/src/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
         <receiver android:name="Receiver">
             <intent-filter>
-                <action android:name="FLASHLIGHT"></action>
+                <action android:name="z4pp3r.flashlightwidget.FLASHLIGHT"></action>
             </intent-filter>
         </receiver>
 

--- a/src/java/z4pp3r/flashlightwidget/Main.java
+++ b/src/java/z4pp3r/flashlightwidget/Main.java
@@ -9,19 +9,27 @@ import android.widget.RemoteViews;
 
 public class Main extends AppWidgetProvider {
 
-    @Override
-    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+    static RemoteViews createWidgetView(Context context) {
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.main);
 
+        if(Receiver.isLightOn) {
+            views.setTextViewText(R.id.button, "☼ on");
+        } else {
+            views.setTextViewText(R.id.button, "☼ off");
+        }
 
         Intent receiver = new Intent(context, Receiver.class);
-        receiver.setAction("FLASHLIGHT");
-        receiver.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, appWidgetIds);
+        receiver.setAction("z4pp3r.flashlightwidget.FLASHLIGHT");
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, receiver, 0);
-
-        RemoteViews views = new RemoteViews(context.getPackageName(),
-                R.layout.main);
         views.setOnClickPendingIntent(R.id.button, pendingIntent);
 
+        return views;
+    }
+
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        RemoteViews views = createWidgetView(context);
         appWidgetManager.updateAppWidget(appWidgetIds, views);
     }
 

--- a/src/java/z4pp3r/flashlightwidget/Receiver.java
+++ b/src/java/z4pp3r/flashlightwidget/Receiver.java
@@ -6,25 +6,13 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.hardware.Camera;
-import android.widget.RemoteViews;
 
 public class Receiver extends BroadcastReceiver {
-    private static boolean isLightOn = false;
+    static boolean isLightOn = false;
     private static Camera camera;
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.main);
-
-        if(isLightOn) {
-            views.setTextViewText(R.id.button, "☼ off");
-        } else {
-            views.setTextViewText(R.id.button, "☼ on");
-        }
-
-        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
-        appWidgetManager.updateAppWidget(new ComponentName(context,     Main.class), views);
-
         if (isLightOn) {
             if (camera != null) {
                 camera.stopPreview();
@@ -45,5 +33,8 @@ public class Receiver extends BroadcastReceiver {
                 } catch (Exception e) {}
             }
         }
+
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+        appWidgetManager.updateAppWidget(new ComponentName(context, Main.class), Main.createWidgetView(context));
     }
 }


### PR DESCRIPTION
Previously RemoteViews were created with set intent in Main and with set text in Receiver, however, while these changes were merged when widget wasn't recreated by lockscreen, when I toggled flashlight, unlocked and locked back phone, the widget was recreated using only RemoteViews from Receiver and therefore it didn't triggered any action.

This fixes that by moving both creations of RemoteViews to new method which sets both text and intent set.
